### PR TITLE
Fix exception name in bin/pocket

### DIFF
--- a/bin/pocket
+++ b/bin/pocket
@@ -62,6 +62,6 @@ begin
   options.validate!
 
   Cli.dispatch options
-rescue ArgumentError, ParseError, RubyPocketError => e
+rescue ArgumentError, OptionParser::ParseError, RubyPocketError => e
   abort "Error: #{e.message}"
 end


### PR DESCRIPTION
In rare ocasions the Ruby interpreter would not find "ParseError", so I renamed it to "OptionParser::ParserError".