### PR TITLE
Fix test coverage report and Minitest class name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 db/*.db
+coverage

--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,11 @@ require 'rake'
 end
 
 def run_tests(test_files)
-  require 'minitest/autorun'
+  require 'minitest'
 
   test_files.each { |file | require file.expand_path }
+
+  Minitest.run
 end
 
 desc 'Run unit tests'

--- a/test/support/default_test_case.rb
+++ b/test/support/default_test_case.rb
@@ -1,6 +1,6 @@
 require 'support/custom_assertions'
 
-class DefaultTestCase < MiniTest::Test
+class DefaultTestCase < Minitest::Test
   include CustomAssertions
 
   alias :assert_not :refute


### PR DESCRIPTION
The test coverage was not right, because it was being generated before minitest/autorun kicked in. Also fixed a "typo" in Minitest class name: from MiniTest to Minitest.

P.S.: Considering Rake TestTask in the future.