### PR TITLE
Feature: Partial tag matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## [UNRELEASED] - 2015-10-04
+### Added
+- Partial tag matching
+
 ## [0.1.3] - 2015-09-19
 ### Fixed
 - Migrations directory on gem was wrong

--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ $ pocket -l -t command-line
 +----+------------------------------------------------------------------+--------------------+
 ```
 
+Filter favorites by partial tag matching:
+
+```sh
+$ pocket -l -t /line/
+
++----+------------------------------------------------------------------+--------------------+
+| ID | Name                                                             | Tags               |
++----+------------------------------------------------------------------+--------------------+
+| 2  | The Art of Command Line                                          | command-line       |
++----+------------------------------------------------------------------+--------------------+
+```
+
 Open a favorite in your default browser. Use the ID of the favorite:
 
 ```sh
@@ -138,7 +150,6 @@ Favorite 'The Art of Command Line' deleted
 - Edit favorites.
 - List available tags.
 - Interactive command mode.
-- Search favorites with partial tag matching.
 - Search favorites by name or by content, with regex support.
 - Group favorites by tag, and other useful view modes.
 - Link database to another folder, such as **Dropbox**. That action shall be

--- a/lib/ruby_pocket/favorite_query.rb
+++ b/lib/ruby_pocket/favorite_query.rb
@@ -1,8 +1,10 @@
 require 'ruby_pocket/favorite'
+require 'ruby_pocket/tags_query_helper'
 
 module RubyPocket
   class FavoriteQuery
     extend Forwardable
+    include TagsQueryHelper
 
     def self.where(options)
       new.where(options)
@@ -16,7 +18,7 @@ module RubyPocket
 
     def where(options)
       if options[:tag_names]
-        tags = Tag.find_all(options[:tag_names])
+        tags = find_all_tags(options[:tag_names])
         @scope = where_tags(tags)
       end
 
@@ -27,7 +29,7 @@ module RubyPocket
 
     def where_tags(tags)
       tags.reduce(@scope) do |scope, tag|
-        scope.where(tags: tag)
+        scope.where(tag)
       end
     end
   end

--- a/lib/ruby_pocket/tag.rb
+++ b/lib/ruby_pocket/tag.rb
@@ -2,14 +2,6 @@ module RubyPocket
   class Tag < Sequel::Model
     plugin :validation_helpers
 
-    def self.find_all(names)
-      names.map do |name|
-        find(name: name).tap do |tag|
-          fail ArgumentError, "Tag #{name} not found" unless tag
-        end
-      end
-    end
-
     def name=(name)
       super parameterize_name(name)
     end

--- a/lib/ruby_pocket/tags_query_helper.rb
+++ b/lib/ruby_pocket/tags_query_helper.rb
@@ -1,0 +1,32 @@
+require 'ruby_pocket/tag'
+
+module RubyPocket
+  module TagsQueryHelper
+    private
+
+    def find_all_tags(names)
+      names.map { |name| find_tag_match(name) }
+    end
+
+    def find_tag_match(name)
+      if name.start_with?(?/) && name.end_with?(?/)
+        find_partial_tag_match(name)
+      else
+        find_exact_tag_match(name)
+      end
+    end
+
+    def find_exact_tag_match(name)
+      found_tag = Tag.find(name: name).tap do |tag|
+        fail ArgumentError, "Tag #{name} not found" unless tag
+      end
+
+      { tags: found_tag }
+    end
+
+    def find_partial_tag_match(name)
+      tags = Tag.where(Sequel.like(:name, name.gsub(?/, ?%))).all
+      Sequel.or(tags: tags)
+    end
+  end
+end


### PR DESCRIPTION
Implemented partial tag matching feature. I'm not satisfied 100% with the internal changes, but it works. Information on how to use it is on README, although incomplete. You can also do something like this, as pictured in the tests:

```sh
pocket  -l -t /rub/,screencasts
```

That will do an AND query.

I'll put complete documentation on README when its time.